### PR TITLE
develop

### DIFF
--- a/.github/workflows/mirror-content.yml
+++ b/.github/workflows/mirror-content.yml
@@ -13,8 +13,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: |
-          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_STATE
+      - id: date
+        run: |
+          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - uses: olivr/copybara-action@v1.2.3
         with:
           access_token: ${{ github.token }}
@@ -28,7 +29,7 @@ jobs:
             binder||.binder
             tutorial||
           push_replace: |
-            GH_ACTIONS_DATE||${{ env.date }}
+            GH_ACTIONS_DATE||${{ steps.date.outputs.date }}
           workflow: push
 
   mirror-to-tutorial-branch:
@@ -37,8 +38,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - run: |
-          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_STATE
+      - id: date
+        run: |
+          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - uses: olivr/copybara-action@v1.2.3
         with:
           access_token: ${{ github.token }}
@@ -52,5 +54,5 @@ jobs:
             binder/environment.yml||environment.yml
             tutorial||
           push_replace: |
-            GH_ACTIONS_DATE||${{ env.date }}
+            GH_ACTIONS_DATE||${{ steps.date.outputs.date }}
           workflow: push


### PR DESCRIPTION
- update data files
- simplify environment specification
- update notebook and fix typos
- update notebook html preveiw
- minor fixes and updates
- add workflow to build and publish notebook html
- resize figures
- fix notebook publishing workflow
- fix nbconvert workflow
- use gh actions to update notebook date
- update workflows
- fix date replacement in copybara action
- migrate away from using set-output
- fix replacement in copybara action
- fix copybara action syntax
- fix date replacement in copybara workflow
- reverse text replacement operator
- replace date placeholder
- use GITHUB_OUTPUT instead of GITHUB_STATE
- fix setting date in github state environment
- revert back to using the github output environment
